### PR TITLE
feat: add support for flat arrays

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # geom-center-and-normalize
 
-Center a simplicial complex geometry's positions and scale them to fill 1x1x1 bounding box.
+Center a simplicial complex geometry's positions in place and scale them to fill a defined bounding box.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ const normalizedPositions = centerAndNormalize(positions);
 
 ## API
 
-#### `centerAndNormalize(positions): positions`
+#### `centerAndNormalize(positions, [options]): positions`
 
 **Parameters**
 
-- positions: `TypedArray|Array` – simplicial complex geometry positions (eg. `new Float32Array([x, y, z, x, y, z, ...])` or `new Array([x, y, z], [x, y, z], ...)`)
+- positions: `TypedArray|Array` – simplicial complex geometry positions (eg. `new Float32Array([x, y, z, x, y, z, ...])/new Array(x, y, z, x, y, z, ...) ` or `new Array([x, y, z], [x, y, z], ...)`)
+
+- options: `{ center: boolean, normalize: boolean }` – only center or normalize. Both defaults to `true`.
 
 **Returns**
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const normalizedPositions = centerAndNormalize(positions);
 
 **Returns**
 
-- positions: `TypedArray | Array | Array<[x, y, z]>` – The positions parameter array updated, centered at `[0, 0, 0]` and normalized to a unit bounding box `[-0.5, -0.5, -0.5] x [0.5, 0.5, 0.5]`.
+- positions: `TypedArray | Array | Array<[x, y, z]>` – The positions parameter array updated, centered at `[0, 0, 0]` and normalized to a bounding box of `scale` size (`[-halfScale, -halfScale, -halfScale] x [halfScale, halfScale, halfScale]`).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ const normalizedPositions = centerAndNormalize(positions);
 
 **Parameters**
 
-- positions: `TypedArray|Array` – simplicial complex geometry positions (eg. `new Float32Array([x, y, z, x, y, z, ...])/new Array(x, y, z, x, y, z, ...) ` or `new Array([x, y, z], [x, y, z], ...)`)
+- positions: `TypedArray | Array | Array<[x, y, z]>` – simplicial complex geometry positions (eg. `new Float32Array([x, y, z, x, y, z, ...])/new Array(x, y, z, x, y, z, ...)` or `new Array([x, y, z], [x, y, z], ...)`)
 
-- options: `{ center: boolean, normalize: boolean }` – only center or normalize. Both defaults to `true`.
+- options: `{ center: boolean, scale: number | boolean }` – enable/disable centering and enable/disable/control scaling. `center` defaults to `true`. Scale defaults to `1` and can be set to `false` to disable normalization.
 
 **Returns**
 
-- positions: `TypedArray|Array` – The positions parameter array updated, centered at `[0, 0, 0]` and normalized to a unit bounding box `[-0.5, -0.5, -0.5] x [0.5, 0.5, 0.5]`.
+- positions: `TypedArray | Array | Array<[x, y, z]>` – The positions parameter array updated, centered at `[0, 0, 0]` and normalized to a unit bounding box `[-0.5, -0.5, -0.5] x [0.5, 0.5, 0.5]`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const normalizedPositions = centerAndNormalize(positions);
 
 - positions: `TypedArray | Array | Array<[x, y, z]>` – simplicial complex geometry positions (eg. `new Float32Array([x, y, z, x, y, z, ...])/new Array(x, y, z, x, y, z, ...)` or `new Array([x, y, z], [x, y, z], ...)`)
 
-- options: `{ center: boolean, scale: number | boolean }` – enable/disable centering and enable/disable/control scaling. `center` defaults to `true`. Scale defaults to `1` and can be set to `false` to disable normalization.
+- options: `{ center: boolean, normalize: boolean, scale: number }` – enable/disable centering/normalizing and control normalized scaling. `center` and `normalize` defaults to `true`. Scale defaults to `1`.
 
 **Returns**
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function centerAndNormalize(
 
   if (normalize) {
     const size = aabb.size(bbox);
-    scale = scale / Math.max(...size);
+    scale = scale / (Math.max(...size) || 1);
   }
 
   for (let i = 0; i < positionsCount; i++) {

--- a/index.js
+++ b/index.js
@@ -3,19 +3,19 @@ import { aabb } from "pex-geom";
 
 const TEMP_VEC3 = vec3.create();
 
-function centerAndNormalize(positions, { center = true, scale = 1 } = {}) {
-  scale = scale === true ? 1 : scale;
-
+function centerAndNormalize(
+  positions,
+  { center = true, normalize = true, scale = 1 } = {},
+) {
   const isFlatArray = !positions[0]?.length;
   const positionsCount = positions.length / (isFlatArray ? 3 : 1);
 
   const bbox = aabb.fromPoints(aabb.create(), positions);
   const bboxCenter = aabb.center(bbox);
 
-  const normalize = Number.isFinite(scale);
   if (normalize) {
     const size = aabb.size(bbox);
-    scale /= Math.max(...size);
+    scale = scale / Math.max(...size);
   }
 
   for (let i = 0; i < positionsCount; i++) {

--- a/index.js
+++ b/index.js
@@ -2,17 +2,16 @@ import { avec3, vec3 } from "pex-math";
 import { aabb } from "pex-geom";
 
 function centerAndNormalize(positions) {
-  const isTypedArray = !Array.isArray(positions);
-  const stride = isTypedArray ? 3 : 1;
+  const isFlatArray = !positions[0]?.length;
+  const l = positions.length / (isFlatArray ? 3 : 1);
 
-  const bbox = aabb.create();
-  aabb.fromPoints(bbox, positions);
+  const bbox = aabb.fromPoints(aabb.create(), positions);
   const center = aabb.center(bbox);
   const size = aabb.size(bbox);
   const scale = 1 / Math.max(...size);
 
-  for (let i = 0; i < positions.length / stride; i++) {
-    if (isTypedArray) {
+  for (let i = 0; i < l; i++) {
+    if (isFlatArray) {
       avec3.sub(positions, i, center, 0);
       avec3.scale(positions, i, scale);
     } else {

--- a/index.js
+++ b/index.js
@@ -3,17 +3,20 @@ import { aabb } from "pex-geom";
 
 const TEMP_VEC3 = vec3.create();
 
-function centerAndNormalize(
-  positions,
-  { center = true, normalize = true } = {},
-) {
+function centerAndNormalize(positions, { center = true, scale = 1 } = {}) {
+  scale = scale === true ? 1 : scale;
+
   const isFlatArray = !positions[0]?.length;
   const positionsCount = positions.length / (isFlatArray ? 3 : 1);
 
   const bbox = aabb.fromPoints(aabb.create(), positions);
   const bboxCenter = aabb.center(bbox);
-  const size = aabb.size(bbox);
-  const scale = 1 / Math.max(...size);
+
+  const normalize = Number.isFinite(scale);
+  if (normalize) {
+    const size = aabb.size(bbox);
+    scale /= Math.max(...size);
+  }
 
   for (let i = 0; i < positionsCount; i++) {
     if (isFlatArray) {

--- a/index.js
+++ b/index.js
@@ -1,24 +1,35 @@
 import { avec3, vec3 } from "pex-math";
 import { aabb } from "pex-geom";
 
-function centerAndNormalize(positions) {
+const TEMP_VEC3 = vec3.create();
+
+function centerAndNormalize(
+  positions,
+  { center = true, normalize = true } = {},
+) {
   const isFlatArray = !positions[0]?.length;
-  const l = positions.length / (isFlatArray ? 3 : 1);
+  const positionsCount = positions.length / (isFlatArray ? 3 : 1);
 
   const bbox = aabb.fromPoints(aabb.create(), positions);
-  const center = aabb.center(bbox);
+  const bboxCenter = aabb.center(bbox);
   const size = aabb.size(bbox);
   const scale = 1 / Math.max(...size);
 
-  for (let i = 0; i < l; i++) {
+  for (let i = 0; i < positionsCount; i++) {
     if (isFlatArray) {
-      avec3.sub(positions, i, center, 0);
-      avec3.scale(positions, i, scale);
+      avec3.sub(positions, i, bboxCenter, 0);
+      if (normalize) {
+        avec3.scale(positions, i, scale);
+        if (!center) avec3.add(positions, i, bboxCenter, 0);
+      }
     } else {
-      const p = vec3.copy(positions[i]);
-      vec3.sub(p, center);
-      vec3.scale(p, scale);
-      positions[i] = p;
+      vec3.set(TEMP_VEC3, positions[i]);
+      vec3.sub(TEMP_VEC3, bboxCenter);
+      if (normalize) {
+        vec3.scale(TEMP_VEC3, scale);
+        if (!center) vec3.add(TEMP_VEC3, bboxCenter);
+      }
+      vec3.set(positions[i], TEMP_VEC3);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "pex-geom": "^3.0.0-alpha.3",
-        "pex-math": "^4.0.0-alpha.3"
+        "pex-geom": "^3.0.1",
+        "pex-math": "^4.1.0"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -18,40 +18,40 @@
       }
     },
     "node_modules/pex-geom": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/pex-geom/-/pex-geom-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-VxwL3JgaH34gWY/ft1//TftiigrER9WWC4p2Q3sfjOJH9FyHRqgYACkT8j/XlR2140PP7sBRUQoZSA4jKSY5bA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pex-geom/-/pex-geom-3.0.1.tgz",
+      "integrity": "sha512-5wDQnn103lyuisUIuJgDt+ZonvCcIbcfAG5wDr+hJcohSphJlPvtLc1LkneSqt/XESIetKkDaVw3bW+talYPXw==",
       "dependencies": {
-        "pex-math": "^4.0.0-alpha.2"
+        "pex-math": "^4.0.0"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/pex-math": {
-      "version": "4.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.0.0-alpha.3.tgz",
-      "integrity": "sha512-4rHCFNLQnk/NHAQczW/VCBiXOPN2DvAjYhZw5EnEadtMLoI9tGQWd4JxANeV1i3O17PdfIoTi9ECfIRRkz8nwg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.1.0.tgz",
+      "integrity": "sha512-rpb92xRnGan4qOh0cXk8kD4GXXvt6ntQykkegjSU186pJ6uGJ/UJJ3amt9SQenmiEQHU2SXKvZImyzo1RTX61w==",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=9.6.4"
       }
     }
   },
   "dependencies": {
     "pex-geom": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/pex-geom/-/pex-geom-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-VxwL3JgaH34gWY/ft1//TftiigrER9WWC4p2Q3sfjOJH9FyHRqgYACkT8j/XlR2140PP7sBRUQoZSA4jKSY5bA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pex-geom/-/pex-geom-3.0.1.tgz",
+      "integrity": "sha512-5wDQnn103lyuisUIuJgDt+ZonvCcIbcfAG5wDr+hJcohSphJlPvtLc1LkneSqt/XESIetKkDaVw3bW+talYPXw==",
       "requires": {
-        "pex-math": "^4.0.0-alpha.2"
+        "pex-math": "^4.0.0"
       }
     },
     "pex-math": {
-      "version": "4.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.0.0-alpha.3.tgz",
-      "integrity": "sha512-4rHCFNLQnk/NHAQczW/VCBiXOPN2DvAjYhZw5EnEadtMLoI9tGQWd4JxANeV1i3O17PdfIoTi9ECfIRRkz8nwg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.1.0.tgz",
+      "integrity": "sha512-rpb92xRnGan4qOh0cXk8kD4GXXvt6ntQykkegjSU186pJ6uGJ/UJJ3amt9SQenmiEQHU2SXKvZImyzo1RTX61w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geom-center-and-normalize",
   "version": "2.0.0",
-  "description": "Center a simplicial complex geometry's positions and scale them to fill 1x1x1 bounding box.",
+  "description": "Center a simplicial complex geometry's positions in place and scale them to fill a defined bounding box.",
   "keywords": [
     "geom",
     "center",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "test:watch": "node --test --watch test"
   },
   "dependencies": {
-    "pex-geom": "^3.0.0-alpha.3",
-    "pex-math": "^4.0.0-alpha.3"
+    "pex-geom": "^3.0.1",
+    "pex-math": "^4.1.0"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=20.0.0",
+    "npm": ">=9.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "type": "module",
   "exports": "./index.js",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "release": "snowdev release",
     "test": "node --test",

--- a/test/index.js
+++ b/test/index.js
@@ -90,3 +90,52 @@ test("should normalize positions uniformly", (t) => {
 
   assert.deepStrictEqual(centerAndNormalize(positions), normalizedPositions);
 });
+
+test("should only center positions", (t) => {
+  // prettier-ignore
+  const positions = new Float32Array([
+    0, 0, 0,
+    2, 0, 0,
+    2, 2, 0,
+    0, 2, 0,
+  ]);
+
+  // prettier-ignore
+  const normalizedPositions = new Float32Array([
+    -1, -1, 0,
+    1, -1, 0,
+    1, 1, 0,
+    -1, 1, 0,
+  ]);
+
+  assert.deepStrictEqual(
+    centerAndNormalize(positions, { normalize: false }),
+    normalizedPositions
+  );
+  assert.equal(centerAndNormalize(positions), positions);
+});
+test("should only normalize positions", (t) => {
+  // prettier-ignore
+  const positions = new Float32Array([
+    0, 0, 0,
+    10, 0, 0,
+    10, 10, 0,
+    0, 10, 0,
+    10, 10, 10,
+  ]);
+
+  // prettier-ignore
+  const normalizedPositions = new Float32Array([
+    4.5, 4.5, 4.5,
+    5.5, 4.5, 4.5,
+    5.5, 5.5, 4.5,
+    4.5, 5.5, 4.5,
+    5.5, 5.5, 5.5,
+  ]);
+
+  assert.deepStrictEqual(
+    centerAndNormalize(positions, { center: false }),
+    normalizedPositions
+  );
+  assert.equal(centerAndNormalize(positions), positions);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -182,3 +182,24 @@ test(`should center and normalize for scale 2 and return that array`, (t) => {
   );
   assert.equal(centerAndNormalize(positions, { scale: 2 }), positions);
 });
+
+test("should scale to 0", (t) => {
+  // prettier-ignore
+  const positions = new Float32Array([
+    1, 1, 1,
+    2, 2, 2,
+    3, 5, 3
+  ]);
+
+  // prettier-ignore
+  const normalizedPositions = new Float32Array([
+    0, 0, 0,
+    0, 0, 0,
+    0, 0, 0,
+  ]);
+
+  assert.deepEqual(
+    centerAndNormalize(positions, { scale: 0 }),
+    normalizedPositions,
+  );
+});

--- a/test/index.js
+++ b/test/index.js
@@ -109,10 +109,10 @@ test("should only center positions", (t) => {
   ]);
 
   assert.deepStrictEqual(
-    centerAndNormalize(positions, { scale: false }),
+    centerAndNormalize(positions, { normalize: false }),
     normalizedPositions,
   );
-  assert.equal(centerAndNormalize(positions, { scale: false }), positions);
+  assert.equal(centerAndNormalize(positions, { normalize: false }), positions);
 });
 test("should only normalize positions", (t) => {
   // prettier-ignore

--- a/test/index.js
+++ b/test/index.js
@@ -203,3 +203,20 @@ test("should scale to 0", (t) => {
     normalizedPositions,
   );
 });
+test("should handle array of zero positions", (t) => {
+  // prettier-ignore
+  const positions = new Float32Array([
+    0, 0, 0,
+    0, 0, 0,
+    0, 0, 0,
+  ]);
+
+  // prettier-ignore
+  const normalizedPositions = new Float32Array([
+    0, 0, 0,
+    0, 0, 0,
+    0, 0, 0,
+  ]);
+
+  assert.deepEqual(centerAndNormalize(positions), normalizedPositions);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -109,10 +109,10 @@ test("should only center positions", (t) => {
   ]);
 
   assert.deepStrictEqual(
-    centerAndNormalize(positions, { normalize: false }),
-    normalizedPositions
+    centerAndNormalize(positions, { scale: false }),
+    normalizedPositions,
   );
-  assert.equal(centerAndNormalize(positions), positions);
+  assert.equal(centerAndNormalize(positions, { scale: false }), positions);
 });
 test("should only normalize positions", (t) => {
   // prettier-ignore
@@ -135,7 +135,50 @@ test("should only normalize positions", (t) => {
 
   assert.deepStrictEqual(
     centerAndNormalize(positions, { center: false }),
-    normalizedPositions
+    normalizedPositions,
   );
-  assert.equal(centerAndNormalize(positions), positions);
+  assert.equal(centerAndNormalize(positions, { center: false }), positions);
+});
+
+test(`should center and normalize for scale "true" and return that array`, (t) => {
+  // prettier-ignore
+  const positions = new Float32Array([
+    1, 1, 1,
+    2, 2, 2,
+    3, 5, 3
+  ]);
+
+  // prettier-ignore
+  const normalizedPositions = new Float32Array([
+    -0.25, -0.5, -0.25,
+    0, -0.25, 0,
+    0.25, 0.5, 0.25,
+  ]);
+
+  assert.deepStrictEqual(
+    centerAndNormalize(positions, { scale: true }),
+    normalizedPositions,
+  );
+  assert.equal(centerAndNormalize(positions, { scale: true }), positions);
+});
+test(`should center and normalize for scale 2 and return that array`, (t) => {
+  // prettier-ignore
+  const positions = new Float32Array([
+    1, 1, 1,
+    2, 2, 2,
+    3, 5, 3
+  ]);
+
+  // prettier-ignore
+  const normalizedPositions = new Float32Array([
+    -0.25, -0.5, -0.25,
+    0, -0.25, 0,
+    0.25, 0.5, 0.25,
+  ]).map((n) => n * 2);
+
+  assert.deepStrictEqual(
+    centerAndNormalize(positions, { scale: 2 }),
+    normalizedPositions,
+  );
+  assert.equal(centerAndNormalize(positions, { scale: 2 }), positions);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import centerAndNormalize from "../index.js";
 
-test("should normalize an array and return that array", (t) => {
+test("should normalize a typed array and return that array", (t) => {
   // prettier-ignore
   const positions = new Float32Array([
     1, 1, 1,
@@ -22,7 +22,26 @@ test("should normalize an array and return that array", (t) => {
   assert.equal(centerAndNormalize(positions), positions);
 });
 
-test("should normalize an array of positions and return that array", (t) => {
+test("should normalize a flat array of positions and return that array", (t) => {
+  // prettier-ignore
+  const positions = [
+    1, 1, 1,
+    2, 2, 2,
+    3, 5, 3
+  ];
+
+  // prettier-ignore
+  const normalizedPositions = [
+    -0.25, -0.5, -0.25,
+    0, -0.25, 0,
+    0.25, 0.5, 0.25,
+  ];
+
+  assert.deepStrictEqual(centerAndNormalize(positions), normalizedPositions);
+  assert.equal(centerAndNormalize(positions), positions);
+});
+
+test("should normalize an array of position arrays and return that array", (t) => {
   // prettier-ignore
   const positions = [
     [1, 1, 1],


### PR DESCRIPTION
- do we want "just center" and "just normalize" features? If so, what should be the API: `can(positions, { centerOnly, normalizeOnly })` ?